### PR TITLE
Fixed docstring regarding values of kphio

### DIFF
--- a/R/rpmodel.R
+++ b/R/rpmodel.R
@@ -18,9 +18,9 @@
 #' standard atmosphere (101325 Pa), corrected for elevation (argument \code{elv}), using the function
 #' \link{calc_patm}), if argument \code{patm} is not provided. If argument \code{patm} is provided,
 #' \code{elv} is overridden.
-#' @param kphio Apparent quantum yield efficiency (unitless). Defaults to 0.0817 for
-#' \code{method_jmaxlim="wang17", do_ftemp_kphio=TRUE, do_soilmstress=FALSE}, 0.0870 for
-#' \code{method_jmaxlim="wang17", do_ftemp_kphio=TRUE, do_soilmstress=TRUE}, and 0.0492 for
+#' @param kphio Apparent quantum yield efficiency (unitless). Defaults to 0.0818 for
+#' \code{method_jmaxlim="wang17", do_ftemp_kphio=TRUE, do_soilmstress=FALSE}, 0.0872 for
+#' \code{method_jmaxlim="wang17", do_ftemp_kphio=TRUE, do_soilmstress=TRUE}, and 0.0499 for
 #' \code{method_jmaxlim="wang17", do_ftemp_kphio=FALSE, do_soilmstress=FALSE}, corresponding to the empirically
 #' fitted value as presented in Stocker et al. (2019) Geosci. Model Dev. for model setup 'BRC', 'FULL', and 'ORG'
 #' respectively.


### PR DESCRIPTION
Values of phi (`kphio`) as stated in docstring were not in agreement with model code (`rpmodel` function signature). For example, if `do_ftemp_kphio = FALSE & do_soilmstress = FALSE`, `kphio` should be 0.049977. This can actually lead to a difference of ~1 g C m-2 day-1 at high PAR/ high PPFD.